### PR TITLE
감정 투표 관련 api

### DIFF
--- a/src/main/kotlin/shop/maeum/domain/diary/api/DiaryController.kt
+++ b/src/main/kotlin/shop/maeum/domain/diary/api/DiaryController.kt
@@ -8,6 +8,7 @@ import shop.maeum.domain.diary.api.dto.response.DiarySummaryResDto
 import shop.maeum.domain.diary.api.dto.response.WriteDiaryResDto
 import shop.maeum.domain.diary.application.DiaryService
 import shop.maeum.global.template.RspTemplate
+import java.security.Principal
 
 @RestController
 @RequestMapping("/api/v1/diaries")
@@ -16,12 +17,14 @@ class DiaryController(
 ) : DiaryDocs {
 
     @PostMapping
-    override fun writeDiary(@RequestBody writeDiaryReqDto: WriteDiaryReqDto): RspTemplate<WriteDiaryResDto> {
+    override fun writeDiary(
+        @RequestBody writeDiaryReqDto: WriteDiaryReqDto
+    ): RspTemplate<WriteDiaryResDto> {
         return RspTemplate(
             httpStatus = HttpStatus.CREATED,
             message = "일기가 성공적으로 작성되었습니다.",
             data = diaryService.writeDiary(
-                writeDiaryReqDto
+                writeDiaryReqDto,
             )
         )
     }

--- a/src/main/kotlin/shop/maeum/domain/diary/api/DiaryController.kt
+++ b/src/main/kotlin/shop/maeum/domain/diary/api/DiaryController.kt
@@ -56,7 +56,7 @@ class DiaryController(
     }
 
     @DeleteMapping("/{diaryId}")
-    fun deleteDiary(
+    override fun deleteDiary(
         @PathVariable diaryId: Long
     ): RspTemplate<Void> {
         diaryService.deleteDiary(diaryId)

--- a/src/main/kotlin/shop/maeum/domain/diary/api/DiaryController.kt
+++ b/src/main/kotlin/shop/maeum/domain/diary/api/DiaryController.kt
@@ -1,14 +1,14 @@
 package shop.maeum.domain.diary.api
 
+import org.springframework.data.domain.PageRequest
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.*
 import shop.maeum.domain.diary.api.dto.request.WriteDiaryReqDto
 import shop.maeum.domain.diary.api.dto.response.DiaryDetailResDto
-import shop.maeum.domain.diary.api.dto.response.DiarySummaryResDto
+import shop.maeum.domain.diary.api.dto.response.DiaryListWithPageResDto
 import shop.maeum.domain.diary.api.dto.response.WriteDiaryResDto
 import shop.maeum.domain.diary.application.DiaryService
 import shop.maeum.global.template.RspTemplate
-import java.security.Principal
 
 @RestController
 @RequestMapping("/api/v1/diaries")
@@ -29,16 +29,19 @@ class DiaryController(
         )
     }
 
-//    @GetMapping
-//    fun getMyDiaries(
-//    ): RspTemplate<List<DiarySummaryResDto>> {
-//        val diaries = diaryService.getDiaries(멤버 보내기)
-//        return RspTemplate(
-//            httpStatus = HttpStatus.OK,
-//            message = "내 일기 리스트 조회 성공",
-//            data = diaries
-//        )
-//    }
+    @GetMapping
+    override fun getDiaries(
+        @RequestParam(name = "page", defaultValue = "0") page: Int,
+        @RequestParam(name = "size", defaultValue = "10") size: Int
+    ): RspTemplate<DiaryListWithPageResDto> {
+        val pageable = PageRequest.of(page, size)
+        val diaries = diaryService.getDiaries(pageable)
+        return RspTemplate(
+            HttpStatus.OK,
+            message = "일기 목록 조회 성공",
+            data = diaries
+        )
+    }
 
     @GetMapping("/{diaryId}")
     override fun getDiaryDetail(

--- a/src/main/kotlin/shop/maeum/domain/diary/api/DiaryDocs.kt
+++ b/src/main/kotlin/shop/maeum/domain/diary/api/DiaryDocs.kt
@@ -7,8 +7,10 @@ import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.parameters.RequestBody
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.web.bind.annotation.RequestParam
 import shop.maeum.domain.diary.api.dto.request.WriteDiaryReqDto
 import shop.maeum.domain.diary.api.dto.response.DiaryDetailResDto
+import shop.maeum.domain.diary.api.dto.response.DiaryListWithPageResDto
 import shop.maeum.domain.diary.api.dto.response.WriteDiaryResDto
 import shop.maeum.global.template.RspTemplate
 
@@ -73,7 +75,6 @@ interface DiaryDocs {
         writeDiaryReqDto: WriteDiaryReqDto
     ): RspTemplate<WriteDiaryResDto>
 
-
     @Operation(
         summary = "일기 상세 조회",
         description = "특정 일기의 상세 정보를 조회합니다. (감정 리스트 포함)"
@@ -109,4 +110,51 @@ interface DiaryDocs {
     fun getDiaryDetail(
         diaryId: Long
     ): RspTemplate<DiaryDetailResDto>
+
+    @Operation(
+        summary = "일기 목록 조회 (페이징)",
+        description = "현재 로그인한 사용자의 일기 목록을 페이지 단위로 조회합니다."
+    )
+    @ApiResponse(
+        responseCode = "200",
+        description = "일기 목록 조회 성공",
+        content = [
+            Content(
+                mediaType = "application/json",
+                schema = Schema(implementation = RspTemplate::class),
+                examples = [
+                    ExampleObject(
+                        name = "일기 목록 조회 예시",
+                        value = """
+                    {
+                      "statusCode": 200,
+                      "message": "일기 목록 조회 성공",
+                      "data": {
+                        "diaries": [
+                          {
+                            "diaryId": 1,
+                            "title": "오늘 하루",
+                            "content": "정말 피곤한 하루였다.",
+                            "feedback": "오늘 하루는 정말 피곤했겠네요.",
+                            "createdAt": "2025-09-02T14:30:00"
+                          }
+                        ],
+                        "pageInfo": {
+                          "currentPage": 0,
+                          "totalPages": 1,
+                          "totalItems": 1
+                        }
+                      }
+                    }
+                    """
+                    )
+                ]
+            )
+        ]
+    )
+    fun getDiaries(
+        @RequestParam(defaultValue = "0", name = "page") page: Int,
+        @RequestParam(defaultValue = "10", name = "size") size: Int
+    ): RspTemplate<DiaryListWithPageResDto>
+
 }

--- a/src/main/kotlin/shop/maeum/domain/diary/api/DiaryDocs.kt
+++ b/src/main/kotlin/shop/maeum/domain/diary/api/DiaryDocs.kt
@@ -1,12 +1,14 @@
 package shop.maeum.domain.diary.api
 
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.ExampleObject
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.parameters.RequestBody
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestParam
 import shop.maeum.domain.diary.api.dto.request.WriteDiaryReqDto
 import shop.maeum.domain.diary.api.dto.response.DiaryDetailResDto
@@ -77,7 +79,7 @@ interface DiaryDocs {
 
     @Operation(
         summary = "일기 상세 조회",
-        description = "특정 일기의 상세 정보를 조회합니다. (감정 리스트 포함)"
+        description = "특정 일기의 상세 정보를 조회합니다. (감정 리스트 및 각 감정의 좋아요 수 포함)"
     )
     @ApiResponse(
         responseCode = "200",
@@ -90,26 +92,55 @@ interface DiaryDocs {
                     ExampleObject(
                         name = "일기 상세 조회 성공 응답 예시",
                         value = """
-                        {
-                          "statusCode": 200,
-                          "message": "일기 상세 조회 성공",
-                          "data": {
-                            "diaryId": 1,
-                            "title": "오늘 하루",
-                            "content": "정말 피곤한 하루였다.",
-                            "feedback": "오늘 하루는 정말 피곤했겠네요. 내일은 더 나아질 거예요.",
-                            "emotions": ["슬픔", "피곤함", "불안", "외로움", "무기력"]
+                    {
+                      "statusCode": 200,
+                      "message": "일기 상세 조회 성공",
+                      "data": {
+                        "diaryId": 1,
+                        "title": "오늘 하루",
+                        "content": "정말 피곤한 하루였다.",
+                        "privacySetting": "PRIVATE",
+                        "feedback": "오늘 하루는 정말 피곤했겠네요. 내일은 더 나아질 거예요.",
+                        "emotions": [
+                          {
+                            "emotionId": 10,
+                            "type": "슬픔",
+                            "likeCount": 3
+                          },
+                          {
+                            "emotionId": 11,
+                            "type": "피곤함",
+                            "likeCount": 5
+                          },
+                          {
+                            "emotionId": 12,
+                            "type": "불안",
+                            "likeCount": 1
+                          },
+                          {
+                            "emotionId": 13,
+                            "type": "외로움",
+                            "likeCount": 0
+                          },
+                          {
+                            "emotionId": 14,
+                            "type": "무기력",
+                            "likeCount": 2
                           }
-                        }
-                        """
+                        ]
+                      }
+                    }
+                    """
                     )
                 ]
             )
         ]
     )
     fun getDiaryDetail(
-        diaryId: Long
+        @Parameter(description = "조회할 일기의 ID")
+        @PathVariable diaryId: Long
     ): RspTemplate<DiaryDetailResDto>
+
 
     @Operation(
         summary = "일기 목록 조회 (페이징)",
@@ -157,4 +188,33 @@ interface DiaryDocs {
         @RequestParam(defaultValue = "10", name = "size") size: Int
     ): RspTemplate<DiaryListWithPageResDto>
 
+    @Operation(
+        summary = "일기 삭제",
+        description = "선택한 일기를 삭제합니다. (Soft Delete)"
+    )
+    @ApiResponse(
+        responseCode = "200",
+        description = "일기 삭제 성공",
+        content = [
+            Content(
+                mediaType = "application/json",
+                schema = Schema(implementation = RspTemplate::class),
+                examples = [
+                    ExampleObject(
+                        name = "일기 삭제 응답 예시",
+                        value = """
+                        {
+                          "statusCode": 200,
+                          "message": "일기가 성공적으로 삭제되었습니다.",
+                          "data": null
+                        }
+                        """
+                    )
+                ]
+            )
+        ]
+    )
+    fun deleteDiary(
+        diaryId: Long
+    ): RspTemplate<Void>
 }

--- a/src/main/kotlin/shop/maeum/domain/diary/api/dto/response/DiaryDetailResDto.kt
+++ b/src/main/kotlin/shop/maeum/domain/diary/api/dto/response/DiaryDetailResDto.kt
@@ -13,10 +13,13 @@ data class DiaryDetailResDto(
 ) {
     companion object {
         fun fromEntity(diary: Diary): DiaryDetailResDto {
-            val emotionCounts = diary.emotions
-                .groupingBy { it.emotionType }
-                .eachCount()
-                .map { (type, count) -> EmotionCountDto(type, count) }
+            val emotionCounts = diary.emotions.map { emotion ->
+                EmotionCountDto(
+                    emotionId = emotion.id!!,
+                    type = emotion.emotionType,
+                    likeCount = emotion.likes.size
+                )
+            }
 
             return DiaryDetailResDto(
                 diaryId = diary.id!!,
@@ -30,7 +33,8 @@ data class DiaryDetailResDto(
     }
 
     data class EmotionCountDto(
+        val emotionId: Long,
         val type: EmotionType,
-        val count: Int
+        val likeCount: Int
     )
 }

--- a/src/main/kotlin/shop/maeum/domain/diary/api/dto/response/DiaryListWithPageResDto.kt
+++ b/src/main/kotlin/shop/maeum/domain/diary/api/dto/response/DiaryListWithPageResDto.kt
@@ -1,0 +1,8 @@
+package shop.maeum.domain.diary.api.dto.response
+
+import shop.maeum.global.dto.PageInfoResDto
+
+data class DiaryListWithPageResDto(
+    val diaries: List<DiarySummaryResDto>,
+    val pageInfo: PageInfoResDto
+)

--- a/src/main/kotlin/shop/maeum/domain/diary/api/dto/response/WriteDiaryResDto.kt
+++ b/src/main/kotlin/shop/maeum/domain/diary/api/dto/response/WriteDiaryResDto.kt
@@ -1,13 +1,16 @@
 package shop.maeum.domain.diary.api.dto.response
+
 import shop.maeum.domain.diary.domain.Diary
 import shop.maeum.domain.diary.domain.PrivacySetting
+import shop.maeum.domain.emotion.domain.EmotionType
 
 data class WriteDiaryResDto(
     val id: Long? = null,
     val title: String,
     val content: String,
     val privacySetting: PrivacySetting,
-    val feedback: String
+    val feedback: String,
+    val emotions: List<EmotionType> 
 ) {
     companion object {
         fun fromEntity(diary: Diary): WriteDiaryResDto {
@@ -16,7 +19,8 @@ data class WriteDiaryResDto(
                 title = diary.title,
                 content = diary.content,
                 privacySetting = diary.privacySetting,
-                feedback = diary.feedback
+                feedback = diary.feedback,
+                emotions = diary.emotions.map { it.emotionType }
             )
         }
     }

--- a/src/main/kotlin/shop/maeum/domain/diary/application/DiaryService.kt
+++ b/src/main/kotlin/shop/maeum/domain/diary/application/DiaryService.kt
@@ -10,15 +10,17 @@ import shop.maeum.domain.diary.domain.Diary
 import shop.maeum.domain.diary.domain.repository.DiaryRepository
 import shop.maeum.global.entity.Status
 import org.slf4j.LoggerFactory
+import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.findByIdOrNull
 import shop.maeum.domain.diary.api.dto.response.DiaryDetailResDto
+import shop.maeum.domain.diary.api.dto.response.DiaryListWithPageResDto
 import shop.maeum.domain.diary.api.dto.response.DiarySummaryResDto
 import shop.maeum.domain.diary.exception.DiaryNotFoundException
 import shop.maeum.domain.emotion.domain.Emotion
 import shop.maeum.domain.emotion.domain.EmotionType
 import shop.maeum.domain.member.repository.MemberRepository
 import shop.maeum.domain.security.util.SecurityUtil
-import java.security.Principal
+import shop.maeum.global.dto.PageInfoResDto
 
 @Service
 @Transactional(readOnly = true)
@@ -95,10 +97,18 @@ class DiaryService(
         return emotions to feedback
     }
 
-//    fun getDiaries(memberId: Long): List<DiarySummaryResDto> {
-//        return diaryRepository.findAllByMemberIdOrderByCreatedAtDesc(memberId)
-//            .map { DiarySummaryResDto.fromEntity(it) }
-//    }
+    fun getDiaries(pageable: Pageable): DiaryListWithPageResDto {
+        val member = memberRepository.findByEmail(securityUtil.getCurrentEmail())
+            ?: throw IllegalArgumentException("Member with email ${securityUtil.getCurrentEmail()} not found")
+
+        val diaryPage = diaryRepository.findAllByMemberIdOrderByCreatedAtDesc(member.id!!, pageable)
+
+        return DiaryListWithPageResDto(
+            diaries = diaryPage.content.map { DiarySummaryResDto.fromEntity(it) },
+            pageInfo = PageInfoResDto.from(diaryPage)
+        )
+    }
+
 
     fun getDiaryDetail(diaryId: Long): DiaryDetailResDto {
         val diary = diaryRepository.findByIdOrNull(diaryId)

--- a/src/main/kotlin/shop/maeum/domain/diary/application/DiaryService.kt
+++ b/src/main/kotlin/shop/maeum/domain/diary/application/DiaryService.kt
@@ -16,12 +16,17 @@ import shop.maeum.domain.diary.api.dto.response.DiarySummaryResDto
 import shop.maeum.domain.diary.exception.DiaryNotFoundException
 import shop.maeum.domain.emotion.domain.Emotion
 import shop.maeum.domain.emotion.domain.EmotionType
+import shop.maeum.domain.member.repository.MemberRepository
+import shop.maeum.domain.security.util.SecurityUtil
+import java.security.Principal
 
 @Service
 @Transactional(readOnly = true)
 class DiaryService(
     private val diaryRepository: DiaryRepository,
     private val aiService: AiService,
+    private val memberRepository: MemberRepository,
+    private val securityUtil: SecurityUtil,
 
     @Value("\${ai.prompt.diary-analysis}")
     private val diaryAnalysisPrompt: String
@@ -30,6 +35,9 @@ class DiaryService(
 
     @Transactional
     fun writeDiary(writeDiaryReqDto: WriteDiaryReqDto): WriteDiaryResDto {
+        val member = memberRepository.findByEmail(securityUtil.getCurrentEmail())
+            ?: throw IllegalArgumentException("Member with id ${securityUtil.getCurrentEmail()} not found")
+
         val fullPrompt = """
         $diaryAnalysisPrompt
 
@@ -50,7 +58,8 @@ class DiaryService(
             content = writeDiaryReqDto.content,
             privacySetting = writeDiaryReqDto.privacySetting,
             feedback = feedback,
-            status = Status.ACTIVE
+            status = Status.ACTIVE,
+            member = member
         )
 
         val emotions = emotionNames.map { name ->

--- a/src/main/kotlin/shop/maeum/domain/diary/application/DiaryService.kt
+++ b/src/main/kotlin/shop/maeum/domain/diary/application/DiaryService.kt
@@ -109,7 +109,6 @@ class DiaryService(
         )
     }
 
-
     fun getDiaryDetail(diaryId: Long): DiaryDetailResDto {
         val diary = diaryRepository.findByIdOrNull(diaryId)
             ?: throw DiaryNotFoundException()

--- a/src/main/kotlin/shop/maeum/domain/diary/domain/Diary.kt
+++ b/src/main/kotlin/shop/maeum/domain/diary/domain/Diary.kt
@@ -5,6 +5,7 @@ import org.hibernate.annotations.SQLDelete
 import org.hibernate.annotations.Where
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
 import shop.maeum.domain.emotion.domain.Emotion
+import shop.maeum.domain.member.entity.Member
 import shop.maeum.global.entity.BaseEntity
 import shop.maeum.global.entity.Status
 
@@ -12,7 +13,7 @@ import shop.maeum.global.entity.Status
 @SQLDelete(sql = "UPDATE diary SET status = 'UN_ACTIVE' WHERE diary_id = ?")
 @Where(clause = "status = 'ACTIVE'")
 @EntityListeners(AuditingEntityListener::class)
-class Diary (
+class Diary(
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -37,8 +38,10 @@ class Diary (
     var status: Status = Status.ACTIVE,
 
     @OneToMany(mappedBy = "diary", cascade = [CascadeType.ALL], orphanRemoval = true)
-    val emotions: MutableList<Emotion> = mutableListOf()
+    val emotions: MutableList<Emotion> = mutableListOf(),
 
-//    @Column(name = "member_id", nullable = false)
-//    val memberId: Long
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    val member: Member
+
 ) : BaseEntity()

--- a/src/main/kotlin/shop/maeum/domain/diary/domain/repository/DiaryRepository.kt
+++ b/src/main/kotlin/shop/maeum/domain/diary/domain/repository/DiaryRepository.kt
@@ -1,8 +1,13 @@
 package shop.maeum.domain.diary.domain.repository
 
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import shop.maeum.domain.diary.domain.Diary
 
 interface DiaryRepository : JpaRepository<Diary, Long> {
-    // fun findAllByMemberIdOrderByCreatedAtDesc(memberId: Long): List<Diary>
+    fun findAllByMemberIdOrderByCreatedAtDesc(
+        memberId: String, pageable: Pageable
+    ): Page<Diary>
+
 }

--- a/src/main/kotlin/shop/maeum/domain/emotion/api/EmotionLikeController.kt
+++ b/src/main/kotlin/shop/maeum/domain/emotion/api/EmotionLikeController.kt
@@ -1,0 +1,25 @@
+package shop.maeum.domain.emotion.api
+
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import shop.maeum.domain.emotion.application.EmotionLikeService
+import shop.maeum.global.template.RspTemplate
+
+@RestController
+@RequestMapping("/api/v1/emotions")
+class EmotionLikeController(
+    private val emotionLikeService: EmotionLikeService
+) : EmotionLikeDocs {
+    @PostMapping("/{emotionId}/like")
+    override fun likeEmotion(@PathVariable emotionId: Long): RspTemplate<String> {
+        emotionLikeService.toggleEmotionLike(emotionId)
+        return RspTemplate(
+            httpStatus = HttpStatus.OK,
+            message = "감정 좋아요 성공",
+            data = "liked"
+        )
+    }
+}

--- a/src/main/kotlin/shop/maeum/domain/emotion/api/EmotionLikeDocs.kt
+++ b/src/main/kotlin/shop/maeum/domain/emotion/api/EmotionLikeDocs.kt
@@ -1,0 +1,47 @@
+package shop.maeum.domain.emotion.api
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+import io.swagger.v3.oas.annotations.Parameter
+import org.springframework.web.bind.annotation.PathVariable
+import shop.maeum.global.template.RspTemplate
+
+@Tag(name = "Emotion", description = "감정 관련 API (좋아요 등)")
+interface EmotionLikeDocs {
+
+    @Operation(
+        summary = "감정 좋아요 토글",
+        description = "해당 감정에 대해 좋아요를 누르거나 취소합니다. 한 번 누르면 좋아요, 다시 누르면 취소됩니다." +
+                "또, 같은 일기 안에서 다른 감정을 누르면 자동으로 이전 좋아요가 취소되고 새로 좋아요가 등록됩니다."
+    )
+    @ApiResponse(
+        responseCode = "200",
+        description = "감정 좋아요 토글 성공",
+        content = [
+            Content(
+                mediaType = "application/json",
+                schema = Schema(implementation = RspTemplate::class),
+                examples = [
+                    ExampleObject(
+                        name = "감정 좋아요 응답 예시",
+                        value = """
+                        {
+                          "statusCode": 200,
+                          "message": "감정 좋아요 성공",
+                          "data": "liked"
+                        }
+                        """
+                    )
+                ]
+            )
+        ]
+    )
+    fun likeEmotion(
+        @Parameter(description = "좋아요를 누를 감정의 ID")
+        @PathVariable emotionId: Long
+    ): RspTemplate<String>
+}

--- a/src/main/kotlin/shop/maeum/domain/emotion/application/EmotionLikeService.kt
+++ b/src/main/kotlin/shop/maeum/domain/emotion/application/EmotionLikeService.kt
@@ -1,0 +1,48 @@
+package shop.maeum.domain.emotion.application
+
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import shop.maeum.domain.diary.repository.EmotionLikeRepository
+import shop.maeum.domain.diary.repository.EmotionRepository
+import shop.maeum.domain.emotion.domain.EmotionLike
+import shop.maeum.domain.emotion.exception.AlreadyLikedEmotionException
+import shop.maeum.domain.emotion.exception.EmotionNotFoundException
+import shop.maeum.domain.member.repository.MemberRepository
+import shop.maeum.domain.security.util.SecurityUtil
+
+@Service
+@Transactional(readOnly = true)
+class EmotionLikeService(
+    private val emotionRepository: EmotionRepository,
+    private val memberRepository: MemberRepository,
+    private val emotionLikeRepository: EmotionLikeRepository,
+    private val securityUtil: SecurityUtil
+) {
+    @Transactional
+    fun toggleEmotionLike(emotionId: Long) {
+        val member = memberRepository.findByEmail(securityUtil.getCurrentEmail())
+            ?: throw IllegalArgumentException("Member not found")
+
+        val targetEmotion = emotionRepository.findByIdOrNull(emotionId)
+            ?: throw EmotionNotFoundException()
+
+        // 가장 먼저 일기 기준으로, 해당 유저가 이미 좋아요한 감정이 있는지 조회
+        val diary = targetEmotion.diary
+        val likedEmotion = emotionLikeRepository.findByEmotion_Diary_IdAndMember_Id(diary.id!!, member.id!!)
+
+        if (likedEmotion != null) {
+            if (likedEmotion.emotion.id == targetEmotion.id) {
+                // 이미 같은 감정 좋아요 했으면 → 좋아요 취소
+                emotionLikeRepository.delete(likedEmotion)
+            } else {
+                // 다른 감정 선택했으면 → 기존 거 삭제하고 새로운 거 생성
+                emotionLikeRepository.delete(likedEmotion)
+                emotionLikeRepository.save(EmotionLike(emotion = targetEmotion, member = member))
+            }
+        } else {
+            // 좋아요한 적 없으면 → 그냥 추가
+            emotionLikeRepository.save(EmotionLike(emotion = targetEmotion, member = member))
+        }
+    }
+}

--- a/src/main/kotlin/shop/maeum/domain/emotion/domain/Emotion.kt
+++ b/src/main/kotlin/shop/maeum/domain/emotion/domain/Emotion.kt
@@ -15,10 +15,11 @@ class Emotion(
     @Column(name = "emotion_type", nullable = false)
     val emotionType: EmotionType,
 
-    @Column(name = "emotion_count", nullable = false)
-    var emotionCount: Int = 0,
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "diary_id", nullable = false)
-    val diary: Diary
+    val diary: Diary,
+
+    @OneToMany(mappedBy = "emotion", cascade = [CascadeType.ALL], orphanRemoval = true)
+    val likes: MutableList<EmotionLike> = mutableListOf()
+
 ) : BaseEntity()

--- a/src/main/kotlin/shop/maeum/domain/emotion/domain/EmotionLike.kt
+++ b/src/main/kotlin/shop/maeum/domain/emotion/domain/EmotionLike.kt
@@ -1,0 +1,21 @@
+package shop.maeum.domain.emotion.domain
+
+import jakarta.persistence.*
+import shop.maeum.domain.member.entity.Member
+import shop.maeum.global.entity.BaseEntity
+
+@Entity
+class EmotionLike(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "emotion_id")
+    val emotion: Emotion,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    val member: Member,
+) : BaseEntity()

--- a/src/main/kotlin/shop/maeum/domain/emotion/domain/repository/EmotionLikeRepository.kt
+++ b/src/main/kotlin/shop/maeum/domain/emotion/domain/repository/EmotionLikeRepository.kt
@@ -4,7 +4,8 @@ import org.springframework.data.jpa.repository.JpaRepository
 import shop.maeum.domain.emotion.domain.EmotionLike
 
 interface EmotionLikeRepository : JpaRepository<EmotionLike, Long> {
-    fun existsByEmotion_Diary_IdAndMember_Id(diaryId: Long, memberId: String): Boolean
-
-    fun countByEmotion_Id(emotionId: Long): Long
+    fun findByEmotion_Diary_IdAndMember_Id(
+        emotion_diary_id: Long, member_id: String
+    ): EmotionLike?
 }
+

--- a/src/main/kotlin/shop/maeum/domain/emotion/domain/repository/EmotionLikeRepository.kt
+++ b/src/main/kotlin/shop/maeum/domain/emotion/domain/repository/EmotionLikeRepository.kt
@@ -1,0 +1,10 @@
+package shop.maeum.domain.diary.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import shop.maeum.domain.emotion.domain.EmotionLike
+
+interface EmotionLikeRepository : JpaRepository<EmotionLike, Long> {
+    fun existsByEmotion_Diary_IdAndMember_Id(diaryId: Long, memberId: String): Boolean
+
+    fun countByEmotion_Id(emotionId: Long): Long
+}

--- a/src/main/kotlin/shop/maeum/domain/emotion/domain/repository/EmotionRepository.kt
+++ b/src/main/kotlin/shop/maeum/domain/emotion/domain/repository/EmotionRepository.kt
@@ -1,0 +1,6 @@
+package shop.maeum.domain.diary.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import shop.maeum.domain.emotion.domain.Emotion
+
+interface EmotionRepository : JpaRepository<Emotion, Long>

--- a/src/main/kotlin/shop/maeum/domain/emotion/exception/AlreadyLikedEmotionException.kt
+++ b/src/main/kotlin/shop/maeum/domain/emotion/exception/AlreadyLikedEmotionException.kt
@@ -1,0 +1,5 @@
+package shop.maeum.domain.emotion.exception
+
+import shop.maeum.global.error.exception.InvalidGroupException
+
+class AlreadyLikedEmotionException : InvalidGroupException("이미 좋아요를 누른 감정입니다.")

--- a/src/main/kotlin/shop/maeum/domain/emotion/exception/EmotionNotFoundException.kt
+++ b/src/main/kotlin/shop/maeum/domain/emotion/exception/EmotionNotFoundException.kt
@@ -1,0 +1,5 @@
+package shop.maeum.domain.emotion.exception
+
+import shop.maeum.global.error.exception.NotFoundGroupException
+
+class EmotionNotFoundException : NotFoundGroupException("현재 일기에 존재하지 않는 감정입니다.")

--- a/src/main/kotlin/shop/maeum/domain/jwt/utils/JwtAuthenticationTokenExtractor.kt
+++ b/src/main/kotlin/shop/maeum/domain/jwt/utils/JwtAuthenticationTokenExtractor.kt
@@ -13,15 +13,20 @@ class JwtAuthenticationTokenExtractor(
     fun extractJwtAuthenticationToken(token: String): JwtAuthenticationToken {
         val claims: JwtComponent.Claims = jwtComponent.verify(token)
 
-        val id: String = claims.id.replace("\"", "")
-        val authorities: List<GrantedAuthority> = obtainAuthorities(claims)
+        val id = claims.id.replace("\"", "")
+        val email = claims.email.replace("\"", "")
+        val roles = claims.roles.map { it.replace("\"", "") }
+
+        val authorities = roles.map { role -> SimpleGrantedAuthority("ROLE_$role") }
 
         if (authorities.isEmpty()) throw UsernameNotFoundException("Invalid token")
+
         return JwtAuthenticationToken(
-            JwtAuthentication(id, token),
-            authorities,
+            JwtAuthentication(id, email),
+            authorities
         )
     }
+
 
     private fun obtainAuthorities(claims: JwtComponent.Claims): List<GrantedAuthority> {
         val roles: Array<String> = claims.roles

--- a/src/main/kotlin/shop/maeum/domain/security/config/CorsConfig.kt
+++ b/src/main/kotlin/shop/maeum/domain/security/config/CorsConfig.kt
@@ -1,15 +1,14 @@
 package shop.maeum.domain.security.config
 
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.context.annotation.Configuration
 
 @Configuration
-@ConfigurationProperties(prefix = "cors")
-class CorsConfig(
-    var allowedHeaders: List<String> = listOf("*"),
-    var allowedMethods: List<String> = listOf("GET", "POST", "PUT", "DELETE", "OPTIONS"),
-) {
-    @Value("\${cors.allowed-origins}")
-    lateinit var allowedOrigins: List<String>
+@ConfigurationProperties(prefix = "spring.security.cors")
+class CorsConfig {
+    var allowedOrigins: List<String> = emptyList()
+    var allowedPaths: List<String> = emptyList()
+    var allowedHeaders: List<String> = listOf("*")
+    var allowedMethods: List<String> = listOf("GET", "POST", "PUT", "DELETE", "OPTIONS")
 }
+

--- a/src/main/kotlin/shop/maeum/domain/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/shop/maeum/domain/security/config/SecurityConfig.kt
@@ -19,7 +19,7 @@ import shop.maeum.domain.security.filter.JwtAuthenticationTokenFilter
 class SecurityConfig(
     private val jwtAuthenticationTokenFilter: JwtAuthenticationTokenFilter,
     private val corsConfig: CorsConfig,
-    @Value("\${spring.security.allowed-paths}")
+    @Value("\${spring.security.cors.allowed-paths}")
     private val whiteList : Array<String>
 ) {
     @Bean

--- a/src/main/kotlin/shop/maeum/domain/security/util/SecurityUtil.kt
+++ b/src/main/kotlin/shop/maeum/domain/security/util/SecurityUtil.kt
@@ -1,0 +1,13 @@
+package shop.maeum.domain.security.util
+
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.stereotype.Component
+import shop.maeum.domain.security.authentication.JwtAuthenticationToken
+
+@Component
+object SecurityUtil {
+    fun getCurrentEmail(): String {
+        val auth = SecurityContextHolder.getContext().authentication as JwtAuthenticationToken
+        return auth.principal.email
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
>PR과 연관된 이슈 번호를 작성해주세요. ex) #이슈 번호, #이슈 번호

- close: #6

## 🪄작업 내용
>해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.
>뷰 작업 내용이 포함되었을 경우 사진 혹은 동영상 파일 첨부를 부탁드립니다!

- spring security util을 선언해서 전역객체로 활용하도록 수정
- yml 파일 경로 안 맞는 오류 수정
- member entity 연관관계 연결해서 기존 diary api 수정
- 감정 투표 api 구현


## 💖리뷰 요청사항
>특별히 봐주셨으면 하는 부분, 나 좀 잘했다 하는 부분! 기타 당부의 말씀 등 자유롭게 작성해주세요.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Paginated diary list endpoint (page/size) for easier browsing.
  - Like/unlike emotions on a diary; switching liked emotion is supported.
  - Diary detail now shows per-emotion like counts and identifiers.
  - Diary creation response includes selected emotions.

- Documentation
  - Updated API docs for diary list/detail/delete and the emotion like endpoint, with examples.

- Chores
  - Refined CORS configuration and security settings to improve cross-origin access and authentication handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->